### PR TITLE
Add an html/jquery example to validate AJAX call against the Census API

### DIFF
--- a/census_tract_validator.html
+++ b/census_tract_validator.html
@@ -1,0 +1,341 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+
+</head>
+
+<body>
+    <p>
+        Enter a valid address below, and check (via the CensusGeocoder example from Chad Stoughton) if the address is
+        valid for HarvardFCU, or not.<br />
+        <br />
+        There are no error checking and no styling! I also did not spend much time on the parsing of the address, so be
+        gentle with it? Please.
+    </p>
+    </p>
+    <form id="censusTractValidatorForm">
+        <input type="text" name="address" id="address" />
+        <button id="ButtonForm">Check</button>
+    </form>
+    <p>
+        <strong>Examples:</strong><br />
+        <code>77 Massachusetts Ave, cambridge ma 02139</code> is a supported address<br />
+        <code>148 winthropshore drive, winthrop, ma 02152</code> is NOT a supported address<br />
+    </p>
+
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"
+        integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
+
+    <script>
+        var censusGeocoderUrl = "https://geocoding.geo.census.gov/geocoder/geographies/address";
+
+        const tracts = ["25009202104",
+            "25009205200",
+            "25009205500",
+            "25009205600",
+            "25009205700",
+            "25009205800",
+            "25009205900",
+            "25009206000",
+            "25009206100",
+            "25009206200",
+            "25009206400",
+            "25009206500",
+            "25009206600",
+            "25009206700",
+            "25009206800",
+            "25009206900",
+            "25009207000",
+            "25009207100",
+            "25009207200",
+            "25009208301",
+            "25009208302",
+            "25017336404",
+            "25017339101",
+            "25017339700",
+            "25017339900",
+            "25017341200",
+            "25017341301",
+            "25017341400",
+            "25017341500",
+            "25017341600",
+            "25017341700",
+            "25017341800",
+            "25017341901",
+            "25017341904",
+            "25017342101",
+            "25017342102",
+            "25017342201",
+            "25017342202",
+            "25017342301",
+            "25017342302",
+            "25017342401",
+            "25017342402",
+            "25017342501",
+            "25017342502",
+            "25017342600",
+            "25017350106",
+            "25017350107",
+            "25017350108",
+            "25017350109",
+            "25017351203",
+            "25017351403",
+            "25017351404",
+            "25017351500",
+            "25017352101",
+            "25017352102",
+            "25017352200",
+            "25017352300",
+            "25017352400",
+            "25017352500",
+            "25017352600",
+            "25017352700",
+            "25017352800",
+            "25017352900",
+            "25017353000",
+            "25017353101",
+            "25017353102",
+            "25017353200",
+            "25017353300",
+            "25017353700",
+            "25017353800",
+            "25017353900",
+            "25017354000",
+            "25017354100",
+            "25017357400",
+            "25017359400",
+            "25017370201",
+            "25017370301",
+            "25017370302",
+            "25017370403",
+            "25017373100",
+            "25021400100",
+            "25021400202",
+            "25025000102",
+            "25025000201",
+            "25025000202",
+            "25025000301",
+            "25025000302",
+            "25025000401",
+            "25025000502",
+            "25025000503",
+            "25025000505",
+            "25025000506",
+            "25025000603",
+            "25025000604",
+            "25025000701",
+            "25025000703",
+            "25025000704",
+            "25025000805",
+            "25025000806",
+            "25025000807",
+            "25025010103",
+            "25025010104",
+            "25025010204",
+            "25025010205",
+            "25025010206",
+            "25025010300",
+            "25025010403",
+            "25025010404",
+            "25025010405",
+            "25025010408",
+            "25025010500",
+            "25025020301",
+            "25025020304",
+            "25025030301",
+            "25025030302",
+            "25025040200",
+            "25025040600",
+            "25025040801",
+            "25025050101",
+            "25025050200",
+            "25025050300",
+            "25025050400",
+            "25025050500",
+            "25025050600",
+            "25025050700",
+            "25025050901",
+            "25025051000",
+            "25025051101",
+            "25025060603",
+            "25025060604",
+            "25025060700",
+            "25025061000",
+            "25025061101",
+            "25025061201",
+            "25025061203",
+            "25025070102",
+            "25025070103",
+            "25025070201",
+            "25025070202",
+            "25025070402",
+            "25025070502",
+            "25025070600",
+            "25025070801",
+            "25025070802",
+            "25025070901",
+            "25025070902",
+            "25025071101",
+            "25025071201",
+            "25025080100",
+            "25025080300",
+            "25025080401",
+            "25025080500",
+            "25025080601",
+            "25025080801",
+            "25025080900",
+            "25025081001",
+            "25025081101",
+            "25025081102",
+            "25025081200",
+            "25025081301",
+            "25025081302",
+            "25025081400",
+            "25025081500",
+            "25025081700",
+            "25025081800",
+            "25025081900",
+            "25025082000",
+            "25025082100",
+            "25025090100",
+            "25025090200",
+            "25025090300",
+            "25025090400",
+            "25025090600",
+            "25025090700",
+            "25025090901",
+            "25025091001",
+            "25025091100",
+            "25025091200",
+            "25025091300",
+            "25025091400",
+            "25025091500",
+            "25025091600",
+            "25025091700",
+            "25025091800",
+            "25025091900",
+            "25025092000",
+            "25025092101",
+            "25025092200",
+            "25025092300",
+            "25025092400",
+            "25025100100",
+            "25025100200",
+            "25025100300",
+            "25025100400",
+            "25025100500",
+            "25025100601",
+            "25025101001",
+            "25025101002",
+            "25025101101",
+            "25025101102",
+            "25025110104",
+            "25025110201",
+            "25025110301",
+            "25025110401",
+            "25025110403",
+            "25025120500",
+            "25025130406",
+            "25025140102",
+            "25025140105",
+            "25025140106",
+            "25025140300",
+            "25025140400",
+            "25025160102",
+            "25025160103",
+            "25025160200",
+            "25025160300",
+            "25025160400",
+            "25025160501",
+            "25025160502",
+            "25025160601",
+            "25025160602",
+            "25025170101",
+            "25025170102",
+            "25025170200",
+            "25025170301",
+            "25025170302",
+            "25025170400",
+            "25025170502",
+            "25025170503",
+            "25025170504",
+            "25025170601",
+            "25025170701",
+            "25025170702",
+            "25025170800",
+            "25025180101",
+            "25025980300",
+            "25025981501",
+            "25025981502",
+            "25025981800"];
+
+        function parseAddress(addressString) {
+            // TODO: This is a simplistic assumption
+            const addr = addressString.replace(",", " ").split(/\s+/);
+            return {
+                street: addr[0] + " " + addr[1] + " " + addr[2],
+                city: addr[3],
+                state: addr[4],
+                zip: addr[5]
+            };
+
+            // The Gemini example?!
+            const addressRegex = /^(.*)\s(.*)\s(.*),(\w+),(.*)\s(.*)$/;
+            const match = addressString.match(addressRegex);
+
+            if (match) {
+                return {
+                    street: match[1],
+                    number: match[2],
+                    city: match[3],
+                    state: match[4],
+                    zip: match[5]
+                };
+            } else {
+                return null; // Parsing failed
+            }
+        }
+
+        $('#censusTractValidatorForm').submit(function (evt) {
+            evt.preventDefault();
+            console.log("Would submit form");
+        });
+
+        $("#ButtonForm").click(function () {
+            var address_string = $("#address").val();
+
+            var addr_components = parseAddress(address_string);
+            var params = {
+                'street': addr_components.street,
+                'city': addr_components.city,
+                'state': addr_components.state,
+                'zip': addr_components.zip,
+                'benchmark': 'Public_AR_Census2020',  // Use the 2020 Census benchmark
+                'vintage': 'Census2020_Census2020',  // Census 2020 vintage data
+                'layers': 'tract',  // Specify layers for census tract
+                'format': 'json'  // Get the response in JSON format
+            };
+
+            var response = $.ajax({
+                url: censusGeocoderUrl,
+                method: "get",
+                //dataType: 'jsonp',
+                data: params,
+                success: function (response) {
+                    var firstTractIdFound = response.result['addressMatches'][0]['geographies']['Census Tracts'][0]['GEOID'];
+                    if ((tracts.indexOf(firstTractIdFound) > -1)) {
+                        alert("Success! Your address is within the list of census tracts we can support");
+                    } else {
+                        alert("Unfortunately, that address is not supported by Harvard-FCU");
+                    }
+                },
+                error: function (XMLHttpRequest, textStatus, errorThrown) {
+                    alert("Status: " + textStatus); alert("Error: " + errorThrown);
+                }
+            });
+        });
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
This is just a crude example of a single HTML page file to validate the API call and some of the JS (parsing address and matching response against list of Tract IDs).

There is no styling or error handling in this file. Just using it to validate the AJAX call and parsing the response. For demonstration purposes.